### PR TITLE
[Test practica 3] Calcular el indice correcto si hay instrucciones antes del useradd

### DIFF
--- a/tests/test_practica3.py
+++ b/tests/test_practica3.py
@@ -68,7 +68,7 @@ class TestPractica3(unittest.TestCase):
                     required_options.discard('-k {}'.format(words_in_line[idx_k+1]))
 
             # useradd can have multiple -K options
-            for idx_k in [ i for i, word in enumerate(words_in_line[idx:]) if word == '-K' ]:
+            for idx_k in [ i+idx for i, word in enumerate(words_in_line[idx:]) if word == '-K' ]:
                 if idx_k+1 < length:
                     required_options.discard('-K {}'.format(words_in_line[idx_k+1]))
 

--- a/tests/test_practica3.py
+++ b/tests/test_practica3.py
@@ -54,7 +54,7 @@ class TestPractica3(unittest.TestCase):
              """
 
             idx=words_in_line.index('useradd')
-            lenght=len(words_in_line)
+            length=len(words_in_line)
 
             if '-U' in words_in_line:
                 required_options.remove('-U')
@@ -64,12 +64,12 @@ class TestPractica3(unittest.TestCase):
 
             if '-k' in words_in_line[idx:-1]:
                 idx_k=words_in_line.index('-k')
-                if lenght > idx_k + 1 :
+                if length > idx_k + 1 :
                     required_options.discard('-k {}'.format(words_in_line[idx_k+1]))
 
             # useradd can have multiple -K options
             for idx_k in [ i for i, word in enumerate(words_in_line[idx:]) if word == '-K' ]:
-                if idx_k+1 < lenght:
+                if idx_k+1 < length:
                     required_options.discard('-K {}'.format(words_in_line[idx_k+1]))
 
             if '-K' in words_in_line[idx:-1]:


### PR DESCRIPTION
Al comprobar los flags de usermod del tipo -K, si antes del useradd hay otro comando, se calcula mal el indice de los parametros.

Por ejemplo, si se tiene el siguiente codigo:
```bash
if ...; then
    ...
else useradd -K UID_MIN=1815 $usuario; then
    ...
fi
```

El script fallara en detectar el uso de UID_MIN, dado que el indice estara uno por detras, apuntando a '-K'.
